### PR TITLE
Add dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+# Ignore Git repository metadata
+.git
+
+# Ignore Python bytecode caches
+__pycache__/
+
+# Ignore markdown documentation files
+*.md
+


### PR DESCRIPTION
## Summary
- ignore version control metadata and docs when building Docker images

## Testing
- `python3 -m py_compile train_lstm_language_model.py`


------
https://chatgpt.com/codex/tasks/task_e_68638666a95483329489f9af7cc2e55e